### PR TITLE
cancel app on canceled scan

### DIFF
--- a/app/src/main/java/org/commcarehq/aadharuid/MainActivity.java
+++ b/app/src/main/java/org/commcarehq/aadharuid/MainActivity.java
@@ -30,6 +30,8 @@ public class MainActivity extends ActionBarActivity {
                     returnOdkResult(result);
                     break;
                 case RESULT_CANCELED:
+                    setResult(Activity.RESULT_CANCELED);
+                    finish();
                     break;
             }
 


### PR DESCRIPTION
so when the user hits back from the barcode
they don't end up on a blank app activity
